### PR TITLE
don’t emit input event on mount

### DIFF
--- a/src/components/NavigationRoot.vue
+++ b/src/components/NavigationRoot.vue
@@ -271,7 +271,6 @@ export default {
         }));
       newValue.push(...newPages);
 
-      this.$emit('input', newValue);
       this.pages = response;
     },
     updateGroup(index, updatedGroup) {


### PR DESCRIPTION
this stops Kirby from warning about changes after initializing the plugin and fixes #1 